### PR TITLE
Standardize phpredis extension across all versions. [WIP]

### DIFF
--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -3,7 +3,10 @@ FROM outrigger/apache-php-base
 RUN yum -y install \
       https://www.softwarecollections.org/en/scls/remi/php55more/epel-7-x86_64/download/remi-php55more-epel-7-x86_64.noarch.rpm && \
     yum -y install \
+      gcc-c++ \
+      make \
       php55 \
+      php55-php-devel \
       php55-php-gd \
       php55-php-xml \
       php55-php-pdo \
@@ -21,5 +24,19 @@ ENV PHP_HOME /opt/rh/php55
 RUN ln -sfv ${PHP_HOME}/root/usr/bin/* /usr/bin/ && \
     ln -sfv ${PHP_HOME}/root/usr/sbin/* /usr/sbin/ && \
     ln -sfv /dev/stderr ${PHP_HOME}/root/var/log/php-fpm/error.log
+
+# Install phpredis
+ENV PHPREDIS_VERSION 3.1.2
+RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz" && \
+    tar -xzf /tmp/phpredis.tar.gz -C /tmp && \
+    rm /tmp/phpredis.tar.gz && \
+    cd "/tmp/phpredis-$PHPREDIS_VERSION" && \
+    phpize && \
+    ./configure && \
+    make && \
+    make install
+
+# Cleanup the things needed to build phpredis
+RUN yum -y remove gcc-c++ make php55-php-devel; yum clean all
 
 COPY root /

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -3,7 +3,10 @@ FROM outrigger/apache-php-base
 RUN yum -y install \
       https://www.softwarecollections.org/en/scls/remi/php56more/epel-7-x86_64/download/remi-php56more-epel-7-x86_64.noarch.rpm && \
     yum -y install \
+      gcc-c++ \
+      make \
       rh-php56 \
+      rh-php56-php-devel \
       rh-php56-php-gd \
       rh-php56-php-xml \
       rh-php56-php-pdo \
@@ -21,5 +24,19 @@ ENV PHP_HOME /opt/rh/rh-php56
 RUN ln -sfv ${PHP_HOME}/root/usr/bin/* /usr/bin/ && \
     ln -sfv ${PHP_HOME}/root/usr/sbin/* /usr/sbin/ && \
     ln -svf /dev/stderr /var${PHP_HOME}/log/php-fpm/error.log
+
+# Install phpredis
+ENV PHPREDIS_VERSION 3.1.2
+RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz" && \
+    tar -xzf /tmp/phpredis.tar.gz -C /tmp && \
+    rm /tmp/phpredis.tar.gz && \
+    cd "/tmp/phpredis-$PHPREDIS_VERSION" && \
+    phpize && \
+    ./configure && \
+    make && \
+    make install
+
+# Cleanup the things needed to build phpredis.
+RUN yum -y remove gcc-c++ make rh-php56-php-devel; yum clean all
 
 COPY root /

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -18,8 +18,6 @@ RUN yum -y install \
       php70-php-pecl-memcache \
       php70-php-pecl-xdebug \
       php70-php-mcrypt
-      # There is no PHP 7 support for XHProf yet.
-      # php70-php-pecl-xhprof
 
 ENV PHP_HOME /opt/remi/php70
 RUN ln -sfv ${PHP_HOME}/root/usr/bin/* /usr/bin/ && \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -38,6 +38,6 @@ RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archiv
     make install
 
 # Cleanup the things needed to build phpredis
-RUN yum -y remove gcc-c++ make php70-php-devel; yum clean all
+RUN yum -y remove gcc-c++ make php71-php-devel; yum clean all
 
 COPY root /


### PR DESCRIPTION
This is branched off and targets the 'proposed-master' branch, which may end up as master...

In my testing, php56 was able to build, but I couldn't establish whether phpredis would load. Furthermore, I found that systemd was installed and I found it running in the container when I performed a `docker run`.