### PR TITLE
Initial pass at support for XHProf port to PHP 7 fork.

### DIFF
--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -37,6 +37,18 @@ RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archiv
     make && \
     make install
 
+# Install best identified port of XHProf to PHP 7.
+# See <issue>
+ENV XHPROF_VERSION=1.1
+RUN curl -L -o /tmp/xhprof.tar.gz "https://github.com/longxinH/xhprof/archive/v$XHPROF_VERSION.tar.gz" && \
+    tar -xzf /tmp/xhprof.tar.gz -C /tmp && \
+    rm /tmp/xhprof.tar.gz && \
+    cd "/tmp/xhprof-$XHPROF_VERSION/extension" && \
+    phpize && \
+    ./configure && \
+    make && \
+    make install
+
 # Cleanup the things needed to build phpredis
 RUN yum -y remove gcc-c++ make php71-php-devel; yum clean all
 


### PR DESCRIPTION
After conducting a tour of the state of profiling in PHP 7, I may have found a workable solution.

## Background Research

* uprofiler (the SensioLabs fork of XHProf) is basically unmaintained, having been deprecated by Blackfire.io. The free tier of that service is fine for local development, but not for CI or "large-scale" usage.
* xhprof itself (https://github.com/phacility/xhprof) is mostly stagnant.
* Tideways is doing somewhat supporting this as a free plugin, with the idea that you should-but-don't-have-to integrate with their service. However, they decided to ditch sampling, which is the specific feature needed for Flamegraph support.
* Nobody has taken up the reasonable idea of building a PHP 7 sampling extension.

Which leaves ports in the night with varying degrees of maintenance, and no certainty that any given one of them has a blessing to take over.

In https://github.com/phacility/xhprof/issues/82, it is apparent that there are two higher visibility ports:

* https://github.com/RustJason/xhprof
* https://github.com/longxinH/xhprof

Between the two, I chose the longxinH version, because:
* It has more effort at documentation
* It has more effort at general improvement
* It has the issue queue turned on
* Has made actual releases
* It has more stars

On the other hand:
* Less watchers
* No PRs (which also means less users/less broken)

However, geerlingguy seems to have chosen RustJason's version: https://github.com/geerlingguy/ansible-role-php-xhprof/issues/14.

## Testing the Extension

So far I've got a very minimal test of this extension:

<details><summary>Check the Extension is Enabled</summary>

```
$> docker run --rm -it -e PHP_XHPROF="true" outrigger/apache-php:php71 bash

container$> php -i | grep xhprof
/etc/opt/remi/php71/php.d/15-xhprof.ini,

container$> cat /etc/opt/remi/php71/php.d/15-xhprof.ini
; Enable xhprof extension module


extension = xhprof.so


; You can either pass the directory location as an argument to the constructor
; for XHProfRuns_Default() or set xhprof.output_dir ini param.
xhprof.output_dir = /tmp
```

</details>

<details><summary>Use the Bundled Example to Test</summary>

```
container$> cd /tmp/xhprof-1.1/examples
container$> php sample.php
Array
(
    [foo==>bar] => Array
        (
            [ct] => 5
            [wt] => 9
        )

    [bar==>bar@1] => Array
        (
            [ct] => 4
            [wt] => 4
        )

    [bar@1==>bar@2] => Array
        (
            [ct] => 3
            [wt] => 2
        )

    [bar@2==>bar@3] => Array
        (
            [ct] => 2
            [wt] => 1
        )

    [bar@3==>bar@4] => Array
        (
            [ct] => 1
            [wt] => 0
        )

    [main()==>foo] => Array
        (
            [ct] => 1
            [wt] => 34
        )

    [main()==>xhprof_disable] => Array
        (
            [ct] => 1
            [wt] => 0
        )

    [main()] => Array
        (
            [ct] => 1
            [wt] => 70
        )

)
---------------
Assuming you have set up the http based UI for
XHProf at some address, you can view run at
http://<xhprof-ui-address>/index.php?run=59a24dd01c26c&source=xhprof_foo
---------------

container$> head 59a24dd01c26c.xhprof_foo.xhprof
a:8:{s:9:"foo==>bar";a:2:{s:2:"ct";i:5;s:2:"wt";i:11;}s:11:"bar==>bar@1";a:2:{s:2:"ct";i:4;s:2:"wt";i:5;}s:13:"bar@1==>bar@2";a:2:{s:2:"ct";i:3;s:2:"wt";i:2;}s:13:"bar@2==>bar@3";a:2:{s:2:"ct";i:2;s:2:"wt";i:1;}s:13:"bar@3==>bar@4";a:2:{s:2:"ct";i:1;s:2:"wt";i:0;}s:12:"main()==>foo";a:2:{s:2:"ct";i:1;s:2:"wt";i:51;}s:23:"main()==>xhprof_disable";a:2:{s:2:"ct";i:1;s:2:"wt";i:0;}s:6:"main()";a:2:{s:2:"ct";i:1;s:2:"wt";i:63;}}
```

</details>

## Next Steps

* Determine if this is sufficiently working and stable
* Determine what, if any, basic maintenance criteria we require
* Consider following through with a flamegraph experiment.