### PR TITLE
Addition of PHP 7.2

### DIFF
--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -1,0 +1,46 @@
+FROM outrigger/apache-php-base
+
+RUN yum -y install \
+      https://rpms.remirepo.net/enterprise/remi-release-7.rpm && \
+    yum -y install \
+      gcc-c++ \
+      make \
+      php72 \
+      php72-php-devel \
+      php72-php-gd \
+      php72-php-xml \
+      php72-php-pdo \
+      php72-php-mcrypt \
+      php72-php-mysql \
+      php72-php-mysqlnd \
+      php72-php-mbstring \
+      php72-php-fpm \
+      php72-php-opcache \
+      php72-php-pecl-memcache \
+      php72-php-pecl-xdebug \
+      php72-php-pecl-yaml \
+      php72-php-pecl-zip && \
+      # There is no PHP 7 support for XHProf yet.
+      # php72-php-pecl-xhprof
+    yum clean all
+
+ENV PHP_HOME /opt/remi/php72
+RUN ln -sfv ${PHP_HOME}/root/usr/bin/* /usr/bin/ && \
+    ln -sfv ${PHP_HOME}/root/usr/sbin/* /usr/sbin/ && \
+    ln -sfv /dev/stderr /var${PHP_HOME}/log/php-fpm/error.log
+
+# Install phpredis
+ENV PHPREDIS_VERSION 3.1.2
+RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz" && \
+    tar -xzf /tmp/phpredis.tar.gz -C /tmp && \
+    rm /tmp/phpredis.tar.gz && \
+    cd "/tmp/phpredis-$PHPREDIS_VERSION" && \
+    phpize && \
+    ./configure && \
+    make && \
+    make install && \
+    # Clean up build dependencies.
+    yum -y remove gcc-c++ make php72-php-devel && \
+    yum clean all
+
+COPY root /

--- a/php72/root/etc/confd/conf.d/www.toml
+++ b/php72/root/etc/confd/conf.d/www.toml
@@ -1,0 +1,7 @@
+[template]
+src = "www.conf.tmpl"
+dest = "/etc/opt/remi/php72/php-fpm.d/www.conf"
+uid = 0
+gid = 0
+mode = "0644"
+keys = []

--- a/php72/root/etc/confd/conf.d/xdebug.ini.toml
+++ b/php72/root/etc/confd/conf.d/xdebug.ini.toml
@@ -1,0 +1,7 @@
+[template]
+src = "xdebug.ini.tmpl"
+dest = "/etc/opt/remi/php72/php.d/15-xdebug.ini"
+uid = 0
+gid = 0
+mode = "0644"
+keys = []

--- a/php72/root/etc/confd/conf.d/xhprof.ini.toml
+++ b/php72/root/etc/confd/conf.d/xhprof.ini.toml
@@ -1,0 +1,7 @@
+[template]
+src = "xhprof.ini.tmpl"
+dest = "/etc/opt/remi/php72/php.d/15-xhprof.ini"
+uid = 0
+gid = 0
+mode = "0644"
+keys = []

--- a/php72/root/etc/confd/conf.d/yaml.ini.toml
+++ b/php72/root/etc/confd/conf.d/yaml.ini.toml
@@ -1,0 +1,7 @@
+[template]
+src = "yaml.ini.tmpl"
+dest = "/etc/opt/remi/php72/php.d/40-yaml.ini"
+uid = 0
+gid = 0
+mode = "0644"
+keys = []

--- a/php72/root/etc/fix-attrs.d/01-apache-logs-dir
+++ b/php72/root/etc/fix-attrs.d/01-apache-logs-dir
@@ -1,0 +1,1 @@
+/var/log/httpd true apache 0644 0755

--- a/php72/root/etc/opt/remi/php71/php.d/90-redis.ini
+++ b/php72/root/etc/opt/remi/php71/php.d/90-redis.ini
@@ -1,0 +1,1 @@
+extension=redis.so

--- a/php72/root/etc/services.d/php-fpm/run
+++ b/php72/root/etc/services.d/php-fpm/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv sh
+
+exec php-fpm -F -R


### PR DESCRIPTION
Copied note from build container addition of PHP 7.2
Looked at potentially using ius repo instead of remi and found the following differences:

IUS doesn't appear to have these packages:
  mysql (just mysqlnd)
  posix
  mcrypt
  pecl-yaml
  pecl-zip

And renames a few (outside of the general rename to prefix with php72u)
  php-fpm -> fpm
  pecl-memcache -> pecl-memcached

Didn't explore the differences deeply